### PR TITLE
Add generateFragmentTypesString script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ Create a schema string from the result of the introspection query and write it t
 ```bash
 npm run generate-schema-string
 ```
+
+#### Generate a fragment types string
+
+Creates a fragment types JSON file from the result of the introspection query and write it to disk. The resulting file can be used in Apollo Client's `IntrospectionFragmentMatcher` as a solution for working with unions/interfaces.

--- a/bin/generateFragmentTypesString.js
+++ b/bin/generateFragmentTypesString.js
@@ -1,0 +1,31 @@
+const { ensureDirSync } = require('./utils/ensureDirSync')
+const fs = require('fs')
+const config = require('../config')
+
+/**
+ * Filters the introspection response to only include interfaces and unions.
+ */
+
+const INPUT_FILE =
+  process.env.INPUT_FILE ||
+  `${config.outputPath}/${config.fileNames.introspection}`
+const OUTPUT_FILE = process.env.OUTPUT_FILE || config.fileNames.fragmentTypes
+const OUTPUT = `${config.outputPath}/${OUTPUT_FILE}`
+
+console.log(`Reading introspection file: ${INPUT_FILE} ...`)
+const introspectionSchemaResult = JSON.parse(fs.readFileSync(INPUT_FILE))
+
+console.log('Building fragment Types string ...')
+const fragmentTypes = introspectionSchemaResult.__schema.types.filter(
+  type => type.possibleTypes !== null,
+)
+
+const schemaWithFragmentTypesOnly = {
+  ...introspectionSchemaResult,
+  __schema: { ...introspectionSchemaResult.__schema, types: fragmentTypes },
+}
+
+console.log('Writing result to file ...')
+ensureDirSync(config.outputPath)
+fs.writeFileSync(OUTPUT, JSON.stringify(schemaWithFragmentTypesOnly, null, 2))
+console.log(`Result written to \`${OUTPUT}\``)

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "fileNames": {
     "schemaObject": "schema.json",
     "schemaString": "schema.graphql",
-    "introspection": "introspection.json"
+    "introspection": "introspection.json",
+    "fragmentTypes": "fragmentTypes.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "introspect": "node ./bin/introspect.js",
     "generate-schema-object": "node ./bin/generateSchemaObject",
     "generate-schema-string": "node ./bin/generateSchemaString",
-    "start": "npm run introspect && npm run generate-schema-object && npm run generate-schema-string",
+    "generate-fragment-types-string": "node ./bin/generateFragmentTypesString",
+    "start": "npm run introspect && npm run generate-schema-object && npm run generate-schema-string && npm run generate-fragment-types-string",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Kalo Pilato",


### PR DESCRIPTION
Adds a `generateFragmentTypesString` script which takes the introspected schema and filters it, only keeping the types with `possibleTypes` - this can then be used in the `IntrospectionFragmentMatcher` as defined in Apollo Client v2 ([here](https://www.apollographql.com/docs/react/v2/data/fragments/#fragments-on-unions-and-interfaces)).